### PR TITLE
Fix Styling in Safari

### DIFF
--- a/src/stylesheets/editor.styl
+++ b/src/stylesheets/editor.styl
@@ -1,4 +1,5 @@
 @require "mixins/page-text"
+@require "mixins/flex"
 
 editor-width = 700px
 editor-header-width = editor-width - 40
@@ -24,8 +25,8 @@ user-select()
 
 #editor-header, #editor-footer
   position absolute
-  display flex
-  flex-direction row
+  display-flex()
+  flex-direction(row)
   justify-content center
   align-items stretch
 
@@ -43,7 +44,7 @@ user-select()
 
 #editor-container
   position relative
-  display flex
+  display-flex()
   width editor-width px
   min-width editor-width px
   background #fff
@@ -70,7 +71,7 @@ user-select()
   top -1px
 
 .toolbar-section
-  flex 1
+  flex(1)
   text-align center
 
 .toolbar-section:first-child

--- a/src/stylesheets/left-sidebar.styl
+++ b/src/stylesheets/left-sidebar.styl
@@ -18,7 +18,7 @@ dark-brown = #644B2B
 
 #left-sidebar-container
   position relative
-  flex-grow 1
+  flex-grow(1)
   padding-right 0
 
   width 100%

--- a/src/stylesheets/mixins/flex.styl
+++ b/src/stylesheets/mixins/flex.styl
@@ -3,10 +3,6 @@ flex(n)
   -webkit-flex n
 
 display-flex()
-  // The ordering below is important for proper cascading in browsers
-  display -webkit-box
-  display -moz-boxn
-  display -ms-flexbox
   display -webkit-flex
   display flex
   

--- a/src/stylesheets/mixins/flex.styl
+++ b/src/stylesheets/mixins/flex.styl
@@ -1,0 +1,23 @@
+flex(n)
+  flex n
+  -webkit-flex n
+
+display-flex()
+  // The ordering below is important for proper cascading in browsers
+  display -webkit-box
+  display -moz-boxn
+  display -ms-flexbox
+  display -webkit-flex
+  display flex
+  
+flex-direction(n)
+  flex-direction n
+  -webkit-flex-direction n
+  
+flex-grow(n)
+  flex-grow n
+  -webkit-flex-grow n
+  
+flex-shrink(n)
+  flex-shrink n
+  -webkit-flex-shrink n

--- a/src/stylesheets/page.styl
+++ b/src/stylesheets/page.styl
@@ -1,9 +1,11 @@
+@require "mixins/flex"
+
 page-background = rgb(100, 90, 128)
 page-default-text = rgb(40, 35, 76)
 
 #page
-  position relative
-  display flex
+  position relative 
+  display-flex()
   flex-direction row
   justify-content center
   align-items stretch

--- a/src/stylesheets/right-sidebar.styl
+++ b/src/stylesheets/right-sidebar.styl
@@ -1,4 +1,5 @@
 @require "mixins/page-text"
+@require "mixins/flex"
 @require "page"
 @require "sidebars"
 
@@ -10,7 +11,7 @@ search-notes-color = rgb(152, 125, 152)
 
 #right-sidebar-container
   position relative
-  flex-grow 1
+  flex-grow(1)
 
   margin-left 8px
 
@@ -31,7 +32,7 @@ search-notes-color = rgb(152, 125, 152)
   cursor text
   border none
   padding 0 12px
-  flex-grow 1
+  flex-grow(1)
   font-size 18px
   height 36px
   margin-top 2px
@@ -71,7 +72,7 @@ search-notes-color = rgb(152, 125, 152)
   font-size 18px
   padding 8px
   cursor pointer
-  display flex
+  display-flex()
 
   margin-bottom 8px
 
@@ -83,7 +84,7 @@ search-notes-color = rgb(152, 125, 152)
     background-color note-hover
 
 .note-listing-title
-  flex 1
+  flex(1)
 
 .note-listing-icon
   margin-right 6px
@@ -96,10 +97,10 @@ search-notes-color = rgb(152, 125, 152)
 
 #current-note-title-container
   font-size 24px
-  display flex
+  display-flex()
 
 #current-note-title
-  flex-grow 1
+  flex-grow(1)
 
 #close-current-note
   font-size 18px
@@ -111,7 +112,8 @@ search-notes-color = rgb(152, 125, 152)
     color black
 
 #current-note-controls
-  display flex
+  display-flex()
+  
   justify-content space-between
   padding-left 16px
   padding-right 16px

--- a/src/stylesheets/sidebars.styl
+++ b/src/stylesheets/sidebars.styl
@@ -1,3 +1,4 @@
+@require "mixins/flex"
 @require "page"
 
 header-control-color  = rgb(208, 191, 195)
@@ -7,16 +8,17 @@ header-body-element   = rgb(147, 134, 160)
 
 .sidebar
   font-family 'Ubuntu', Helvetica, Arial, sans-serif
-  display flex
-  flex-direction column
+  display-flex()
+  flex-direction(column)
   padding 8px
 
 .sidebar-header
-  display flex
+  display-flex()
   justify-content space-between
   box-sizing border-box
   height 58px
   flex-shrink 0
+  -webkit-flex-shrink 0
 
 .sidebar-header-control
   font-size 32px
@@ -34,4 +36,4 @@ header-body-element   = rgb(147, 134, 160)
 .sidebar-footer
   height 48px
   padding-top 16px
-  flex-shrink 0
+  flex-shrink(0)


### PR DESCRIPTION
Safari requires `-webkit-` prefixed flex styles.

Fixes #44 